### PR TITLE
Add komoditas listing and detail

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -12,6 +12,7 @@ import 'package:rfc_apps/view/pembeli/homepage/produk/detail_produk.dart';
 import 'package:rfc_apps/view/pembeli/homepage/umkm/tokoInformation.dart';
 import 'package:rfc_apps/view/pembeli/homepage/umkm/tokoProduk.dart';
 import 'package:rfc_apps/view/penjual/komoditas.dart';
+import 'package:rfc_apps/view/penjual/detail_komoditas.dart';
 import 'package:rfc_apps/view/penjual/penjualan/detailPendapatan.dart';
 import 'package:rfc_apps/view/penjual/penjualan/riwayatPenjualan.dart';
 import 'package:rfc_apps/view/penjual/produk/detail_produk.dart';
@@ -159,6 +160,10 @@ class MyApp extends StatelessWidget {
         },
         '/saldo': (context) => SaldoPage(),
         '/komoditas': (context) => Komoditas(),
+        '/detail_komoditas': (context) {
+          final id = ModalRoute.of(context)!.settings.arguments as String;
+          return DetailKomoditasPage(id: id);
+        },
         '/mutasi_saldo': (context) => RiwayatMutasiPage(),
         '/informasi_rekening': (context) => const InformasiRekeningPage(),
       },

--- a/lib/model/komoditas.dart
+++ b/lib/model/komoditas.dart
@@ -1,0 +1,122 @@
+class JenisBudidaya {
+  final String id;
+  final String nama;
+  final String latin;
+  final bool status;
+  final String detail;
+  final String tipe;
+  final String gambar;
+  final bool isDeleted;
+  final String createdAt;
+  final String updatedAt;
+
+  JenisBudidaya({
+    required this.id,
+    required this.nama,
+    required this.latin,
+    required this.status,
+    required this.detail,
+    required this.tipe,
+    required this.gambar,
+    required this.isDeleted,
+    required this.createdAt,
+    required this.updatedAt,
+  });
+
+  factory JenisBudidaya.fromJson(Map<String, dynamic> json) {
+    return JenisBudidaya(
+      id: json['id'] ?? '',
+      nama: json['nama'] ?? '',
+      latin: json['latin'] ?? '',
+      status: json['status'] ?? false,
+      detail: json['detail'] ?? '',
+      tipe: json['tipe'] ?? '',
+      gambar: json['gambar'] ?? '',
+      isDeleted: json['isDeleted'] ?? false,
+      createdAt: json['createdAt'] ?? '',
+      updatedAt: json['updatedAt'] ?? '',
+    );
+  }
+}
+
+class Satuan {
+  final String id;
+  final String nama;
+  final String lambang;
+  final bool isDeleted;
+  final String createdAt;
+  final String updatedAt;
+
+  Satuan({
+    required this.id,
+    required this.nama,
+    required this.lambang,
+    required this.isDeleted,
+    required this.createdAt,
+    required this.updatedAt,
+  });
+
+  factory Satuan.fromJson(Map<String, dynamic> json) {
+    return Satuan(
+      id: json['id'] ?? '',
+      nama: json['nama'] ?? '',
+      lambang: json['lambang'] ?? '',
+      isDeleted: json['isDeleted'] ?? false,
+      createdAt: json['createdAt'] ?? '',
+      updatedAt: json['updatedAt'] ?? '',
+    );
+  }
+}
+
+class KomoditasData {
+  final String id;
+  final String nama;
+  final String gambar;
+  final int jumlah;
+  final bool hapusObjek;
+  final String tipeKomoditas;
+  final bool isDeleted;
+  final String? produkId;
+  final String createdAt;
+  final String updatedAt;
+  final String jenisBudidayaId;
+  final String satuanId;
+  final JenisBudidaya jenisBudidaya;
+  final Satuan satuan;
+
+  KomoditasData({
+    required this.id,
+    required this.nama,
+    required this.gambar,
+    required this.jumlah,
+    required this.hapusObjek,
+    required this.tipeKomoditas,
+    required this.isDeleted,
+    required this.produkId,
+    required this.createdAt,
+    required this.updatedAt,
+    required this.jenisBudidayaId,
+    required this.satuanId,
+    required this.jenisBudidaya,
+    required this.satuan,
+  });
+
+  factory KomoditasData.fromJson(Map<String, dynamic> json) {
+    return KomoditasData(
+      id: json['id'] ?? '',
+      nama: json['nama'] ?? '',
+      gambar: json['gambar'] ?? '',
+      jumlah: json['jumlah'] ?? 0,
+      hapusObjek: json['hapusObjek'] ?? false,
+      tipeKomoditas: json['tipeKomoditas'] ?? '',
+      isDeleted: json['isDeleted'] ?? false,
+      produkId: json['produkId'],
+      createdAt: json['createdAt'] ?? '',
+      updatedAt: json['updatedAt'] ?? '',
+      jenisBudidayaId: json['JenisBudidayaId'] ?? '',
+      satuanId: json['SatuanId'] ?? '',
+      jenisBudidaya: JenisBudidaya.fromJson(json['JenisBudidaya'] ?? {}),
+      satuan: Satuan.fromJson(json['Satuan'] ?? {}),
+    );
+  }
+}

--- a/lib/response/komoditas.dart
+++ b/lib/response/komoditas.dart
@@ -1,0 +1,29 @@
+import 'package:rfc_apps/model/komoditas.dart';
+
+class KomoditasResponse {
+  final String message;
+  final List<KomoditasData> data;
+  final int totalItems;
+  final int totalPages;
+  final int currentPage;
+
+  KomoditasResponse({
+    required this.message,
+    required this.data,
+    required this.totalItems,
+    required this.totalPages,
+    required this.currentPage,
+  });
+
+  factory KomoditasResponse.fromJson(Map<String, dynamic> json) {
+    return KomoditasResponse(
+      message: json['message'] ?? '',
+      data: (json['data'] as List)
+          .map((item) => KomoditasData.fromJson(item))
+          .toList(),
+      totalItems: json['totalItems'] ?? 0,
+      totalPages: json['totalPages'] ?? 0,
+      currentPage: json['currentPage'] ?? 0,
+    );
+  }
+}

--- a/lib/service/komoditas.dart
+++ b/lib/service/komoditas.dart
@@ -1,0 +1,54 @@
+import 'dart:convert';
+
+import 'package:flutter_dotenv/flutter_dotenv.dart';
+import 'package:http/http.dart' as http;
+import 'package:rfc_apps/response/komoditas.dart';
+import 'package:rfc_apps/service/token.dart';
+
+class KomoditasService {
+  final String baseUrl = '${dotenv.env["BASE_URL"]}farm';
+
+  Future<KomoditasResponse> getUnproductKomoditas() async {
+    final token = await tokenService().getAccessToken();
+    final response = await http.get(
+      Uri.parse('$baseUrl/komoditas/unproduct'),
+      headers: {
+        'Content-Type': 'application/json',
+        'Authorization': 'Bearer $token',
+      },
+    );
+
+    if (response.statusCode == 401) {
+      await tokenService().refreshToken();
+      return getUnproductKomoditas();
+    }
+
+    if (response.statusCode == 200) {
+      return KomoditasResponse.fromJson(jsonDecode(response.body));
+    } else {
+      throw Exception('Failed to load komoditas');
+    }
+  }
+
+  Future<KomoditasResponse> getKomoditasById(String id) async {
+    final token = await tokenService().getAccessToken();
+    final response = await http.get(
+      Uri.parse('$baseUrl/komoditas/id/$id'),
+      headers: {
+        'Content-Type': 'application/json',
+        'Authorization': 'Bearer $token',
+      },
+    );
+
+    if (response.statusCode == 401) {
+      await tokenService().refreshToken();
+      return getKomoditasById(id);
+    }
+
+    if (response.statusCode == 200) {
+      return KomoditasResponse.fromJson(jsonDecode(response.body));
+    } else {
+      throw Exception('Failed to load komoditas data');
+    }
+  }
+}

--- a/lib/view/penjual/detail_komoditas.dart
+++ b/lib/view/penjual/detail_komoditas.dart
@@ -1,0 +1,131 @@
+import 'package:flutter/material.dart';
+import 'package:rfc_apps/extension/screen_flexible.dart';
+import 'package:rfc_apps/model/komoditas.dart';
+import 'package:rfc_apps/service/komoditas.dart';
+import 'package:rfc_apps/utils/ShimmerImage.dart';
+
+class DetailKomoditasPage extends StatefulWidget {
+  final String id;
+  const DetailKomoditasPage({super.key, required this.id});
+
+  @override
+  State<DetailKomoditasPage> createState() => _DetailKomoditasPageState();
+}
+
+class _DetailKomoditasPageState extends State<DetailKomoditasPage> {
+  KomoditasData? data;
+
+  @override
+  void initState() {
+    super.initState();
+    _fetch();
+  }
+
+  Future<void> _fetch() async {
+    try {
+      final res = await KomoditasService().getKomoditasById(widget.id);
+      setState(() {
+        data = res.data.first;
+      });
+    } catch (e) {
+      print(e);
+    }
+  }
+
+  Widget _buildRow(String label, String value) {
+    return Padding(
+      padding: const EdgeInsets.symmetric(vertical: 4),
+      child: Row(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          SizedBox(
+            width: 120,
+            child: Text(
+              label,
+              style: TextStyle(
+                fontFamily: 'Poppins',
+                fontSize: 14,
+                fontWeight: FontWeight.w500,
+              ),
+            ),
+          ),
+          const Text(' : ',
+              style: TextStyle(fontFamily: 'Poppins', fontSize: 14)),
+          Expanded(
+            child: Text(
+              value,
+              style: const TextStyle(
+                fontFamily: 'Poppins',
+                fontSize: 14,
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      extendBodyBehindAppBar: true,
+      appBar: AppBar(
+        title: Text('Detail Komoditas',
+            style: TextStyle(
+              color: Colors.white,
+              fontSize: 16,
+              fontFamily: 'Monserrat_Alternates',
+              fontWeight: FontWeight.w600,
+            )),
+        centerTitle: true,
+        backgroundColor: Colors.transparent,
+        elevation: 0,
+        leading: IconButton(
+          icon: const Icon(Icons.arrow_back_ios, color: Colors.white),
+          onPressed: () => Navigator.of(context).pop(),
+        ),
+      ),
+      body: Stack(
+        children: [
+          Container(
+            width: double.infinity,
+            height: double.infinity,
+            child: Image.asset(
+              'assets/images/homebackground.png',
+              fit: BoxFit.fill,
+            ),
+          ),
+          Padding(
+            padding: EdgeInsets.only(
+                left: 20, right: 20, top: context.getHeight(100), bottom: 20),
+            child: data == null
+                ? const Center(child: CircularProgressIndicator())
+                : SingleChildScrollView(
+                    child: Column(
+                      children: [
+                        Container(
+                          width: context.getWidth(300),
+                          height: context.getHeight(300),
+                          child: ClipRRect(
+                            borderRadius: BorderRadius.circular(16),
+                            child: ShimmerImage(
+                              imageUrl: data!.gambar,
+                              fit: BoxFit.cover,
+                            ),
+                          ),
+                        ),
+                        SizedBox(height: context.getHeight(20)),
+                        _buildRow('Nama Komoditas', data!.nama),
+                        _buildRow('Jumlah', data!.jumlah.toString()),
+                        _buildRow('Tipe', data!.tipeKomoditas),
+                        _buildRow('Satuan', data!.satuan.nama),
+                        _buildRow('Jenis Budidaya', data!.jenisBudidaya.nama),
+                      ],
+                    ),
+                  ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/view/penjual/komoditas.dart
+++ b/lib/view/penjual/komoditas.dart
@@ -1,4 +1,8 @@
 import 'package:flutter/material.dart';
+import 'package:rfc_apps/extension/screen_flexible.dart';
+import 'package:rfc_apps/model/komoditas.dart';
+import 'package:rfc_apps/service/komoditas.dart';
+import 'package:rfc_apps/widget/komoditas_card.dart';
 
 class Komoditas extends StatefulWidget {
   const Komoditas({super.key});
@@ -8,15 +12,29 @@ class Komoditas extends StatefulWidget {
 }
 
 class _KomoditasState extends State<Komoditas> {
+  late Future<List<KomoditasData>> _komoditasFuture;
+
+  @override
+  void initState() {
+    super.initState();
+    _komoditasFuture = _fetchKomoditas();
+  }
+
+  Future<List<KomoditasData>> _fetchKomoditas() async {
+    final response = await KomoditasService().getUnproductKomoditas();
+    return response.data;
+  }
+
   @override
   Widget build(BuildContext context) {
     return Scaffold(
+      extendBodyBehindAppBar: true,
       appBar: AppBar(
-        title: Text("Komoditas",
+        title: Text('Komoditas',
             style: TextStyle(
                 color: Colors.white,
                 fontSize: 16,
-                fontFamily: "Monserrat_Alternates",
+                fontFamily: 'Monserrat_Alternates',
                 fontWeight: FontWeight.w600)),
         leading: IconButton(
           icon: const Icon(Icons.arrow_back_ios),
@@ -29,8 +47,48 @@ class _KomoditasState extends State<Komoditas> {
         backgroundColor: Colors.transparent,
         elevation: 0,
       ),
-      body: Center(
-        child: Text("Daftar Komoditas"),
+      body: Stack(
+        children: [
+          Container(
+            width: double.infinity,
+            height: double.infinity,
+            child: Image.asset(
+              'assets/images/homebackground.png',
+              fit: BoxFit.fill,
+            ),
+          ),
+          Padding(
+            padding: EdgeInsets.only(
+                left: 20, right: 20, top: context.getHeight(100), bottom: 20),
+            child: FutureBuilder<List<KomoditasData>>(
+              future: _komoditasFuture,
+              builder: (context, snapshot) {
+                if (snapshot.connectionState == ConnectionState.waiting) {
+                  return const Center(child: CircularProgressIndicator());
+                }
+                if (snapshot.hasError) {
+                  return const Center(child: Text('Gagal memuat komoditas'));
+                }
+                final list = snapshot.data ?? [];
+                if (list.isEmpty) {
+                  return const Center(child: Text('Tidak ada komoditas'));
+                }
+                return GridView.builder(
+                  gridDelegate: const SliverGridDelegateWithFixedCrossAxisCount(
+                    crossAxisCount: 2,
+                    crossAxisSpacing: 20,
+                    mainAxisSpacing: 20,
+                    childAspectRatio: 143 / 160,
+                  ),
+                  itemCount: list.length,
+                  itemBuilder: (context, index) {
+                    return KomoditasCard(komoditas: list[index]);
+                  },
+                );
+              },
+            ),
+          ),
+        ],
       ),
     );
   }

--- a/lib/widget/komoditas_card.dart
+++ b/lib/widget/komoditas_card.dart
@@ -1,0 +1,60 @@
+import 'package:flutter/material.dart';
+import 'package:rfc_apps/extension/screen_flexible.dart';
+import 'package:rfc_apps/model/komoditas.dart';
+import 'package:rfc_apps/utils/ShimmerImage.dart';
+
+class KomoditasCard extends StatelessWidget {
+  final KomoditasData komoditas;
+  const KomoditasCard({super.key, required this.komoditas});
+
+  @override
+  Widget build(BuildContext context) {
+    return GestureDetector(
+      onTap: () {
+        Navigator.pushNamed(
+          context,
+          '/detail_komoditas',
+          arguments: komoditas.id,
+        );
+      },
+      child: Card(
+        color: Colors.white,
+        elevation: 4,
+        shape: RoundedRectangleBorder(
+          side: const BorderSide(color: Colors.grey, width: 0.5),
+          borderRadius: BorderRadius.circular(8),
+        ),
+        child: SizedBox(
+          width: context.getWidth(143),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.center,
+            children: [
+              Container(
+                width: double.infinity,
+                height: context.getHeight(120),
+                child: ClipRRect(
+                  borderRadius: BorderRadius.circular(8),
+                  child:
+                      ShimmerImage(imageUrl: komoditas.gambar, fit: BoxFit.cover),
+                ),
+              ),
+              Padding(
+                padding: const EdgeInsets.all(8.0),
+                child: Text(
+                  komoditas.nama,
+                  style: const TextStyle(
+                    fontSize: 12,
+                    fontWeight: FontWeight.w600,
+                    fontFamily: 'Inter',
+                  ),
+                  maxLines: 1,
+                  overflow: TextOverflow.ellipsis,
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- implement `KomoditasService` for farm API
- add model and response classes for komoditas data
- create card widget and list view for komoditas
- add detail page for komoditas
- wire new route `/detail_komoditas` in `main.dart`

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_68665c5b6c288332947cb40c8d0f0c66