### PR TITLE
Add pull-to-refresh to key pages

### DIFF
--- a/lib/view/pembeli/homepage/histori.dart
+++ b/lib/view/pembeli/homepage/histori.dart
@@ -31,6 +31,10 @@ class _HistoriState extends State<Histori> {
     }
   }
 
+  Future<void> _refreshHistori() async {
+    await _loadPesanan();
+  }
+
   @override
   Widget build(BuildContext context) {
     return Container(
@@ -51,8 +55,11 @@ class _HistoriState extends State<Histori> {
           ),
           SizedBox(height: context.getHeight(20)),
           Expanded(
-            child: ListView.builder(
-              padding: const EdgeInsets.all(16),
+            child: RefreshIndicator(
+              onRefresh: _refreshHistori,
+              child: ListView.builder(
+                physics: const AlwaysScrollableScrollPhysics(),
+                padding: const EdgeInsets.all(16),
               itemCount: _pesananList.length,
               itemBuilder: (context, index) {
                 final pesanan = _pesananList[index];

--- a/lib/view/pembeli/homepage/home.dart
+++ b/lib/view/pembeli/homepage/home.dart
@@ -34,6 +34,13 @@ class _HomeState extends State<Home> {
     });
   }
 
+  Future<void> _refreshHome() async {
+    _loadSaldo();
+    setState(() {
+      _produkListKey = UniqueKey();
+    });
+  }
+
   String formatRupiah(dynamic amount) {
     double numericAmount = 0.0;
     if (amount is String) {
@@ -168,8 +175,11 @@ class _HomeState extends State<Home> {
         Padding(padding: EdgeInsets.only(top: context.getHeight(59))),
         Container(
           height: context.getHeight(670),
-          child: SingleChildScrollView(
-            child: Column(
+          child: RefreshIndicator(
+            onRefresh: _refreshHome,
+            child: SingleChildScrollView(
+              physics: const AlwaysScrollableScrollPhysics(),
+              child: Column(
               children: [
                 FutureBuilder<Map<String, dynamic>>(
                   future: _saldoFuture,

--- a/lib/view/pembeli/homepage/keranjang/keranjang.dart
+++ b/lib/view/pembeli/homepage/keranjang/keranjang.dart
@@ -25,6 +25,12 @@ class _KeranjangState extends State<Keranjang> {
     futureKeranjang = KeranjangService().getAllKeranjang();
   }
 
+  Future<void> _refreshKeranjang() async {
+    setState(() {
+      futureKeranjang = KeranjangService().getAllKeranjang();
+    });
+  }
+
   Map<String, List<CartItem>> groupByToko(List<CartItem> items) {
     Map<String, List<CartItem>> result = {};
     for (var item in items) {
@@ -295,9 +301,11 @@ class _KeranjangState extends State<Keranjang> {
           },
         ),
       ),
-      body: FutureBuilder<List<CartItem>>(
-        future: futureKeranjang,
-        builder: (context, snapshot) {
+      body: RefreshIndicator(
+        onRefresh: _refreshKeranjang,
+        child: FutureBuilder<List<CartItem>>(
+          future: futureKeranjang,
+          builder: (context, snapshot) {
           if (snapshot.connectionState == ConnectionState.waiting) {
             return const Center(child: CircularProgressIndicator());
           }
@@ -318,6 +326,7 @@ class _KeranjangState extends State<Keranjang> {
           return Padding(
             padding: const EdgeInsets.only(bottom: 80),
             child: ListView.builder(
+              physics: const AlwaysScrollableScrollPhysics(),
               padding: const EdgeInsets.all(16),
               itemCount: grouped.length,
               itemBuilder: (context, index) {

--- a/lib/view/penjual/home.dart
+++ b/lib/view/penjual/home.dart
@@ -80,6 +80,13 @@ class _homeSellerState extends State<homeSeller> {
     });
   }
 
+  Future<void> _refreshSellerHome() async {
+    _getTokoDatabyId();
+    getPesananToko();
+    _fetchSaldo();
+    _getPendapatan();
+  }
+
   void _getTokoDatabyId() async {
     try {
       final toko = await tokoService().getTokoByUserId();
@@ -204,20 +211,24 @@ class _homeSellerState extends State<homeSeller> {
         backgroundColor: Colors.transparent,
       ),
       extendBodyBehindAppBar: true,
-      body: Stack(
-        children: [
-          Container(
-            width: double.infinity,
-            height: double.infinity,
-            child: Image.asset(
-              'assets/images/homebackground.png',
-              fit: BoxFit.fill,
+      body: RefreshIndicator(
+        onRefresh: _refreshSellerHome,
+        child: Stack(
+          children: [
+            Container(
+              width: double.infinity,
+              height: double.infinity,
+              child: Image.asset(
+                'assets/images/homebackground.png',
+                fit: BoxFit.fill,
+              ),
             ),
-          ),
-          Container(
-            margin: EdgeInsets.only(
-                left: 20, right: 20, top: context.getHeight(100), bottom: 20),
-            child: Column(
+            SingleChildScrollView(
+              physics: const AlwaysScrollableScrollPhysics(),
+              child: Container(
+                margin: EdgeInsets.only(
+                    left: 20, right: 20, top: context.getHeight(100), bottom: 20),
+                child: Column(
               crossAxisAlignment: CrossAxisAlignment.start,
               children: [
                 const Text(

--- a/lib/view/penjual/komoditas.dart
+++ b/lib/view/penjual/komoditas.dart
@@ -20,6 +20,12 @@ class _KomoditasState extends State<Komoditas> {
     _komoditasFuture = _fetchKomoditas();
   }
 
+  Future<void> _refreshKomoditas() async {
+    setState(() {
+      _komoditasFuture = _fetchKomoditas();
+    });
+  }
+
   Future<List<KomoditasData>> _fetchKomoditas() async {
     final response = await KomoditasService().getUnproductKomoditas();
     return response.data;
@@ -60,9 +66,11 @@ class _KomoditasState extends State<Komoditas> {
           Padding(
             padding: EdgeInsets.only(
                 left: 20, right: 20, top: context.getHeight(100), bottom: 20),
-            child: FutureBuilder<List<KomoditasData>>(
-              future: _komoditasFuture,
-              builder: (context, snapshot) {
+            child: RefreshIndicator(
+              onRefresh: _refreshKomoditas,
+              child: FutureBuilder<List<KomoditasData>>(
+                future: _komoditasFuture,
+                builder: (context, snapshot) {
                 if (snapshot.connectionState == ConnectionState.waiting) {
                   return const Center(child: CircularProgressIndicator());
                 }
@@ -74,6 +82,7 @@ class _KomoditasState extends State<Komoditas> {
                   return const Center(child: Text('Tidak ada komoditas'));
                 }
                 return GridView.builder(
+                  physics: const AlwaysScrollableScrollPhysics(),
                   gridDelegate: const SliverGridDelegateWithFixedCrossAxisCount(
                     crossAxisCount: 2,
                     crossAxisSpacing: 20,

--- a/lib/view/penjual/penjualan/riwayatPenjualan.dart
+++ b/lib/view/penjual/penjualan/riwayatPenjualan.dart
@@ -35,6 +35,10 @@ class _riwayatPenjualanState extends State<riwayatPenjualan> {
     });
   }
 
+  Future<void> _refreshRiwayat() async {
+    await fetchPendapatan();
+  }
+
   void filterByMonth(String? month) {
     if (month == null) return;
 
@@ -139,9 +143,12 @@ class _riwayatPenjualanState extends State<riwayatPenjualan> {
             ),
             SizedBox(height: context.getHeight(20)),
             Expanded(
-              child: filteredData.isEmpty
-                  ? Center(child: Text("Tidak ada data"))
-                  : ListView.builder(
+              child: RefreshIndicator(
+                onRefresh: _refreshRiwayat,
+                child: filteredData.isEmpty
+                    ? Center(child: Text("Tidak ada data"))
+                    : ListView.builder(
+                        physics: const AlwaysScrollableScrollPhysics(),
                       itemCount: filteredData.length,
                       itemBuilder: (context, index) {
                         final item = filteredData[index];

--- a/lib/view/penjual/pesanan/daftar_pesanan.dart
+++ b/lib/view/penjual/pesanan/daftar_pesanan.dart
@@ -91,6 +91,10 @@ class _DaftarPesananState extends State<DaftarPesanan> {
     }
   }
 
+  Future<void> _refreshOrders() async {
+    await _fetchOrders();
+  }
+
   void dispose() {
     _timer?.cancel();
     super.dispose();
@@ -188,18 +192,21 @@ class _DaftarPesananState extends State<DaftarPesanan> {
                       ),
                       const SizedBox(height: 20),
                       Expanded(
-                        child: PageView(
-                          controller: _pageController,
-                          onPageChanged: (index) {
-                            setState(() {
-                              _selectedIndex = index;
-                            });
-                          },
-                          children: [
-                            _buildOrderList(_pesananMasuk),
-                            _buildOrderList(_menungguDiambil),
-                            _buildOrderList(_selesai),
-                          ],
+                        child: RefreshIndicator(
+                          onRefresh: _refreshOrders,
+                          child: PageView(
+                            controller: _pageController,
+                            onPageChanged: (index) {
+                              setState(() {
+                                _selectedIndex = index;
+                              });
+                            },
+                            children: [
+                              _buildOrderList(_pesananMasuk),
+                              _buildOrderList(_menungguDiambil),
+                              _buildOrderList(_selesai),
+                            ],
+                          ),
                         ),
                       )
                     ],
@@ -222,6 +229,7 @@ class _DaftarPesananState extends State<DaftarPesanan> {
       );
     }
     return ListView.builder(
+      physics: const AlwaysScrollableScrollPhysics(),
       padding: EdgeInsets.zero,
       shrinkWrap: true,
       itemCount: orders.length,

--- a/lib/view/pjawab/penarikan/penarikan.dart
+++ b/lib/view/pjawab/penarikan/penarikan.dart
@@ -298,6 +298,7 @@ class _AdminRequestPenarikanPageState extends State<AdminRequestPenarikanPage> {
     }
 
     return ListView.builder(
+      physics: const AlwaysScrollableScrollPhysics(),
       controller: _scrollController,
       itemCount: _requests.length + (_isLoadingMore ? 1 : 0),
       padding: const EdgeInsets.all(12.0),
@@ -441,6 +442,7 @@ class _AdminRequestPenarikanPageState extends State<AdminRequestPenarikanPage> {
       baseColor: Colors.grey[300]!,
       highlightColor: Colors.grey[100]!,
       child: ListView.builder(
+        physics: const AlwaysScrollableScrollPhysics(),
         itemCount: 5,
         padding: const EdgeInsets.all(12.0),
         itemBuilder: (_, __) => Card(

--- a/lib/view/saldo/riwayatMutasi.dart
+++ b/lib/view/saldo/riwayatMutasi.dart
@@ -196,6 +196,7 @@ class _RiwayatMutasiPageState extends State<RiwayatMutasiPage> {
             : _mutasiList.isEmpty && !_isLoading
                 ? _buildEmptyState()
                 : ListView.builder(
+                    physics: const AlwaysScrollableScrollPhysics(),
                     controller: _scrollController,
                     itemCount: _mutasiList.length +
                         (_isLoading && _currentPage <= _totalPages
@@ -289,6 +290,7 @@ class _RiwayatMutasiPageState extends State<RiwayatMutasiPage> {
 
   Widget _buildMutasiListShimmer() {
     return ListView.builder(
+      physics: const AlwaysScrollableScrollPhysics(),
       itemCount: 7,
       padding: const EdgeInsets.symmetric(horizontal: 8.0, vertical: 10.0),
       itemBuilder: (context, index) {

--- a/lib/view/saldo/riwayatPenarikan.dart
+++ b/lib/view/saldo/riwayatPenarikan.dart
@@ -239,6 +239,7 @@ class _RiwayatPenarikanPageState extends State<RiwayatPenarikanPage> {
     }
 
     return ListView.builder(
+      physics: const AlwaysScrollableScrollPhysics(),
       controller: _scrollController,
       itemCount: _penarikanList.length + (_isLoadingMore ? 1 : 0),
       padding: const EdgeInsets.symmetric(vertical: 8.0, horizontal: 12.0),
@@ -341,6 +342,7 @@ class _RiwayatPenarikanPageState extends State<RiwayatPenarikanPage> {
       baseColor: Colors.grey[350]!,
       highlightColor: Colors.grey[200]!,
       child: ListView.builder(
+        physics: const AlwaysScrollableScrollPhysics(),
         itemCount: 5,
         padding: const EdgeInsets.symmetric(vertical: 8.0, horizontal: 12.0),
         itemBuilder: (_, __) => Card(


### PR DESCRIPTION
## Summary
- integrate `RefreshIndicator` into shopping, order history, and seller pages
- expose refresh methods to reload API data
- ensure refresh works on short lists

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_6868711fe86c83329a3968aeb1328f48